### PR TITLE
added the view single post and the comments page

### DIFF
--- a/api/commentsApi.js
+++ b/api/commentsApi.js
@@ -1,0 +1,66 @@
+import { clientCredentials } from '../utils/client';
+
+const endpoint = clientCredentials.databaseURL;
+
+const updateComment = (id, payload) => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/comments/${id}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  }).then((response) => response.json())
+    .then((data) => resolve(Object.values(data)))
+    .catch(reject);
+});
+
+const viewSinglePostComments = (postId) => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/posts/${postId}/comments`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+    .then((response) => response.json())
+    .then((data) => resolve(data))
+    .catch(reject);
+});
+
+const getSingleComment = (id) => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/comments/${id}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+    .then((response) => response.json())
+    .then((data) => resolve(data))
+    .catch(reject);
+});
+
+const deleteComment = (commentId) => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/comments/${commentId}`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+    // .then((response) => response.json())
+    .then((data) => resolve(data))
+    .catch(reject);
+});
+const createComment = (payload) => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/comments/new`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  }).then((response) => response.json())
+    .then((data) => resolve(data))
+    .catch(reject);
+});
+
+export {
+  viewSinglePostComments, updateComment, createComment, deleteComment, getSingleComment,
+};

--- a/components/cards/CommentCard.js
+++ b/components/cards/CommentCard.js
@@ -1,0 +1,45 @@
+import PropTypes from 'prop-types';
+import Card from 'react-bootstrap/Card';
+import { Button } from 'react-bootstrap';
+import Link from 'next/link';
+import { deleteComment } from '../../api/commentsApi';
+
+function CommentCard({ commentObj, onUpdate }) {
+  const deleteThisComment = () => {
+    if (window.confirm(`Delete the comment by ${commentObj.authorName}?`)) {
+      deleteComment(commentObj.id).then(() => onUpdate());
+    }
+  };
+  return (
+    <Card style={{ width: '18rem', margin: '15px auto' }}>
+      <Card.Body>
+        <Card.Title>Author Name: {commentObj.authorName}</Card.Title>
+        <p>{commentObj.content}</p>
+        <p>{commentObj.createdOn}</p>
+        <Link href={`/comments/edit/${commentObj.id}`} passHref>
+          <Button className="editBtn m-2" variant="outline-info">EDIT</Button>
+        </Link>
+        <div>
+          <Button variant="outline-warning" size="sm" onClick={deleteThisComment} className="deleteBtn m-2">
+            DELETE
+          </Button>
+        </div>
+
+      </Card.Body>
+    </Card>
+  );
+}
+
+CommentCard.propTypes = {
+  commentObj: PropTypes.shape({
+    id: PropTypes.number,
+    authorId: PropTypes.number,
+    postId: PropTypes.number,
+    content: PropTypes.string,
+    authorName: PropTypes.string,
+    createdOn: PropTypes.string,
+  }).isRequired,
+  onUpdate: PropTypes.func.isRequired,
+};
+
+export default CommentCard;

--- a/components/cards/postCard.js
+++ b/components/cards/postCard.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import { Card, Button } from 'react-bootstrap';
 import { PropTypes } from 'prop-types';
+import Link from 'next/link';
 
 function PostCard({ postObj }) {
+  console.warn(postObj);
   return (
     <>
       <Card className="card-style" style={{ width: '48rem' }}>
@@ -13,7 +15,9 @@ function PostCard({ postObj }) {
           <Card.Text>{postObj.publicationDate}</Card.Text>
           <br />
           <Card.Text>{postObj.content}</Card.Text>
-          <Button>Details</Button>
+          <Link href={`/posts/${postObj.id}`} passHref>
+            <Button className="editBtn m-2" variant="outline-info">View</Button>
+          </Link>
         </Card.Body>
       </Card>
     </>
@@ -22,6 +26,7 @@ function PostCard({ postObj }) {
 
 PostCard.propTypes = {
   postObj: PropTypes.shape({
+    id: PropTypes.number,
     title: PropTypes.string,
     publicationDate: PropTypes.string,
     authorDisplayName: PropTypes.string,

--- a/components/forms/CommentForm.js
+++ b/components/forms/CommentForm.js
@@ -1,0 +1,90 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Button, Form } from 'react-bootstrap';
+import { useAuth } from '../../utils/context/authContext';
+import { createComment, updateComment } from '../../api/commentsApi';
+
+const initialState = {
+  content: '',
+};
+
+export default function CommentForm({ commentObj, postObj, onUpdate }) {
+  const { user } = useAuth();
+  const [formInput, setFormInput] = useState({
+    ...initialState,
+    postId: postObj ? postObj.id : '',
+  });
+  const router = useRouter();
+
+  useEffect(() => {
+    if (commentObj.id) setFormInput(commentObj);
+  }, [commentObj, user]);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormInput((prevState) => ({
+      ...prevState,
+      [name]: value,
+    }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+
+    if (commentObj.id) {
+      const payload = { createdOn: commentObj.createdOn, ...formInput };
+      updateComment(payload).then(() => router.push(`/user/${commentObj.id}`));
+    } else {
+      createComment({ ...formInput, authorId: user.id }).then(onUpdate);
+    }
+  };
+
+  return (
+    <>
+      <Form onSubmit={handleSubmit} className="userForm">
+        <h1 className="text-white mt-5">{commentObj.id ? 'Update' : 'Add'} User</h1>
+        <Form.Group className="mb-3">
+          <Form.Label>Content</Form.Label>
+          <Form.Control
+            as="textarea"
+            placeholder="Description"
+            style={{ height: '100px' }}
+            name="content"
+            value={formInput.content}
+            onChange={handleChange}
+            required
+          />
+        </Form.Group>
+        <Button variant="outline-secondary" type="submit">
+          {commentObj.id ? 'Update' : 'Add Comment'}
+        </Button>
+      </Form>
+    </>
+  );
+}
+
+CommentForm.propTypes = {
+  commentObj: PropTypes.shape({
+    id: PropTypes.number,
+    authorId: PropTypes.number,
+    postId: PropTypes.number,
+    content: PropTypes.string,
+    createdOn: PropTypes.string,
+  }),
+  postObj: PropTypes.shape({
+    id: PropTypes.number,
+    rareUserId: PropTypes.number,
+    title: PropTypes.string,
+    publicationDate: PropTypes.string,
+    imageUrl: PropTypes.string,
+    content: PropTypes.string,
+    approved: PropTypes.bool,
+  }).isRequired,
+
+  onUpdate: PropTypes.func.isRequired,
+};
+
+CommentForm.defaultProps = {
+  commentObj: initialState,
+};

--- a/pages/comments/edit/[id].js
+++ b/pages/comments/edit/[id].js
@@ -1,0 +1,36 @@
+import { useRouter } from 'next/router';
+import { Button, Card } from 'react-bootstrap';
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { getSingleComment } from '../../../api/commentsApi';
+
+function ViewComment() {
+  const [comment, setComment] = useState({});
+  const router = useRouter();
+  const { id } = router.query;
+
+  const getTheSingleComment = () => {
+    getSingleComment(id).then(setComment);
+  };
+
+  useEffect(() => {
+    getTheSingleComment();
+  }, [id]);
+
+  return (
+    <Card style={{ width: '18rem', margin: '15px auto' }}>
+      <Card.Body>
+        <Card.Title>Author Name: {comment.authorName}</Card.Title>
+        <p>{comment.content}</p>
+        <p>{comment.createdOn}</p>
+        <Link href={`/comments/edit/${comment.id}`} passHref>
+          <Button className="editBtn m-2" variant="outline-info">EDIT</Button>
+        </Link>
+
+      </Card.Body>
+    </Card>
+
+  );
+}
+
+export default ViewComment;

--- a/pages/posts/[id].js
+++ b/pages/posts/[id].js
@@ -1,0 +1,69 @@
+import { Button, Card } from 'react-bootstrap';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { getSinglePost } from '../../api/postsApi';
+import { viewSinglePostComments } from '../../api/commentsApi';
+import CommentCard from '../../components/cards/CommentCard';
+import CommentForm from '../../components/forms/commentForm';
+
+function ViewSinglePost() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [post, setPost] = useState({});
+  const [postDetails, setPostDetails] = useState({});
+  const [commentsSwitch, setCommentsSwitch] = useState(false);
+
+  const getTheSinglePost = () => {
+    getSinglePost(id)?.then(setPost);
+    setCommentsSwitch(false);
+  };
+
+  const viewComments = () => {
+    viewSinglePostComments(post.id).then(setPostDetails);
+    setCommentsSwitch(true);
+  };
+
+  useEffect(() => {
+    getTheSinglePost();
+  }, [id]);
+
+  return (
+    <>
+      {commentsSwitch ? (
+        <>
+          <Button className="editBtn m-2" variant="outline-info" onClick={getTheSinglePost}>
+            Back To Posts
+          </Button>
+          <CommentForm postObj={post} onUpdate={viewComments} />
+          <h2>{postDetails?.title} Comments</h2>
+          {postDetails && postDetails.comments && postDetails.comments.map((comment) => (
+            <CommentCard key={comment.id} commentObj={comment} onUpdate={viewComments} />
+          ))}
+
+        </>
+      ) : (
+        <div>
+          <h1>Post Details</h1>
+          <>
+            <Card className="card-style" style={{ width: '48rem' }}>
+              <Card.Img variant="top" src={post.imageUrl} />
+              <Card.Body>
+                <Card.Title>{post.title}</Card.Title>
+                <Card.Text>By {post.authorDisplayName}</Card.Text>
+                <Card.Text>{post.publicationDate}</Card.Text>
+                <br />
+                <Card.Text>{post.content}</Card.Text>
+                <Button className="editBtn m-2" variant="outline-info" onClick={viewComments}>
+                  View Comments
+                </Button>
+              </Card.Body>
+            </Card>
+          </>
+        </div>
+      )}
+    </>
+
+  );
+}
+
+export default ViewSinglePost;


### PR DESCRIPTION
The single Post page:
-ternary that switches between viewing the single post by id, and by seeing the comment's content forminput with the comment cards that go with that post. 
Api calls for comments (CRUD)
Api call for single post GET request with the comments nested in it.
Edit file to update the comment.
Comment card
Comment form
![image](https://github.com/B33blebroxx/RareFE/assets/119310701/ef6aecf1-54bc-41f4-a2aa-85eb56147a9c)
![image](https://github.com/B33blebroxx/RareFE/assets/119310701/c8c3c909-0073-4f36-a55f-dd2bfc292bab)
